### PR TITLE
[NEW] Add call to chat.sendMessage endpoint

### DIFF
--- a/core/src/main/kotlin/chat/rocket/core/internal/model/PostMessagePayload.kt
+++ b/core/src/main/kotlin/chat/rocket/core/internal/model/PostMessagePayload.kt
@@ -1,0 +1,15 @@
+package chat.rocket.core.internal.model
+
+import chat.rocket.core.model.attachment.Attachment
+import se.ansman.kotshi.JsonSerializable
+
+@JsonSerializable
+data class PostMessagePayload(
+    val roomId: String,
+    val text: String?,
+    val alias: String?,
+    val emoji: String?,
+    val avatar: String?,
+    val attachments: List<Attachment>?,
+    val msgId: String? = null
+)

--- a/core/src/main/kotlin/chat/rocket/core/internal/model/SendMessagePayload.kt
+++ b/core/src/main/kotlin/chat/rocket/core/internal/model/SendMessagePayload.kt
@@ -1,15 +1,21 @@
 package chat.rocket.core.internal.model
 
 import chat.rocket.core.model.attachment.Attachment
+import com.squareup.moshi.Json
 import se.ansman.kotshi.JsonSerializable
 
 @JsonSerializable
-data class MessagePayload(
-    val roomId: String,
-    val text: String?,
+internal data class SendMessageBody(
+    @Json(name = "_id") val id: String? = null,
+    val rid: String,
+    val msg: String?,
     val alias: String?,
     val emoji: String?,
     val avatar: String?,
     val attachments: List<Attachment>?,
     val msgId: String? = null
+)
+
+internal data class SendMessagePayload(
+    val message: SendMessageBody
 )

--- a/core/src/test/kotlin/chat/rocket/core/internal/rest/ChannelTest.kt
+++ b/core/src/test/kotlin/chat/rocket/core/internal/rest/ChannelTest.kt
@@ -45,7 +45,7 @@ class ChannelTest {
             tokenRepository = this@ChannelTest.tokenProvider
             platformLogger = PlatformLogger.NoOpLogger()
         }
-        Mockito.`when`(tokenProvider.get()).thenReturn(authToken)
+        Mockito.`when`(tokenProvider.get(sut.url)).thenReturn(authToken)
     }
 
     @Test

--- a/core/src/test/kotlin/chat/rocket/core/internal/rest/Constants.kt
+++ b/core/src/test/kotlin/chat/rocket/core/internal/rest/Constants.kt
@@ -50,3 +50,23 @@ const val ROLES_OK = """
   "success": true
 }
 """
+//{"message":{"_id":"1abbbf94-c839-4436-9476-6de03011c1e0","rid":"GS3Ceh7BLJGzfto78","msg":"Não"}}
+const val SEND_MESSAGE_WITH_ID_OK = """
+{
+  "message": {
+    "_id": "1abbbf94-c839-4436-9476-6de03011c1e0",
+    "rid": "GENERAL",
+    "msg": "Sending message from SDK to #general and @here",
+    "ts": "2018-04-04T22:37:59.167Z",
+    "u": {
+      "_id": "vKjyfQkgekhXykvKk",
+      "username": "bruce.lee",
+      "name": "Bruce Lee"
+    },
+    "mentions": [],
+    "channels": [],
+    "_updatedAt": "2018-04-04T22:37:59.248Z"
+  },
+  "success": true
+}
+"""

--- a/core/src/test/kotlin/chat/rocket/core/internal/rest/MessagesTest.kt
+++ b/core/src/test/kotlin/chat/rocket/core/internal/rest/MessagesTest.kt
@@ -60,7 +60,7 @@ class MessagesTest {
                 .once()
 
         runBlocking {
-            val msg = sut.sendMessage(roomId = "GENERAL",
+            val msg = sut.postMessage(roomId = "GENERAL",
                     text = "Sending message from SDK to #general and @here",
                     alias = "TestingAlias",
                     emoji = ":smirk:",
@@ -100,6 +100,30 @@ class MessagesTest {
 
                 assertThat(updatedAt, isEqualTo(1511443964808))
                 assertThat(id, isEqualTo("messageId"))
+            }
+        }
+    }
+
+    @Test
+    fun `sendMessage() with id should return a Message object with given id`() {
+        mockServer.expect()
+                .post()
+                .withPath("/api/v1/chat.sendMessage")
+                .andReturn(200, SEND_MESSAGE_WITH_ID_OK)
+                .once()
+
+        runBlocking {
+            val msg = sut.sendMessage(
+                    messageId = "1abbbf94-c839-4436-9476-6de03011c1e0",
+                    roomId = "GENERAL",
+                    message = "Sending message from SDK to #general and @here",
+                    alias = "TestingAlias",
+                    emoji = ":smirk:",
+                    avatar = "https://avatars2.githubusercontent.com/u/224255?s=88&v=4")
+
+            with(msg) {
+                assertThat(message, isEqualTo("Sending message from SDK to #general and @here"))
+                assertThat(id, isEqualTo("1abbbf94-c839-4436-9476-6de03011c1e0"))
             }
         }
     }


### PR DESCRIPTION
As opposed to `chat.postMessage` this endpoint enables the user to pass a predefined message id.