### PR TITLE
[FIX] Fix crash on attachment fields when it has an array with a null value

### DIFF
--- a/core/src/main/kotlin/chat/rocket/core/model/attachment/Field.kt
+++ b/core/src/main/kotlin/chat/rocket/core/model/attachment/Field.kt
@@ -1,9 +1,12 @@
 package chat.rocket.core.model.attachment
 
+import se.ansman.kotshi.JsonDefaultValueString
 import se.ansman.kotshi.JsonSerializable
 
 @JsonSerializable
 data class Field(
+    @JsonDefaultValueString("")
     val title: String,
+    @JsonDefaultValueString("")
     val value: String
 )


### PR DESCRIPTION
Manually parse Fields attribute on Attachment. it can be an array with anull value.