### PR TITLE
Fix Android lint validation failure for unused import (Channel.kt:11:1)

### DIFF
--- a/core/src/main/kotlin/chat/rocket/core/internal/rest/Channel.kt
+++ b/core/src/main/kotlin/chat/rocket/core/internal/rest/Channel.kt
@@ -8,7 +8,6 @@ import chat.rocket.core.model.Room
 import com.squareup.moshi.Types
 import kotlinx.coroutines.experimental.CommonPool
 import kotlinx.coroutines.experimental.withContext
-import okhttp3.Request
 import okhttp3.RequestBody
 
 /**


### PR DESCRIPTION
Original failure:

```
alex@alex:~/dev/Rocket.Chat.Kotlin.SDK.alexfdz$ ./gradlew clean build
w: /home/alex/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jre7/1.2.21/3beb08c67673033183c8652572680587876e64b5/kotlin-stdlib-jre7-1.2.21.jar: kotlin-stdlib-jre7 is deprecated. Please use kotlin-stdlib-jdk7 instead
w: /home/alex/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jre7/1.2.21/3beb08c67673033183c8652572680587876e64b5/kotlin-stdlib-jre7-1.2.21.jar: kotlin-stdlib-jre7 is deprecated. Please use kotlin-stdlib-jdk7 instead
w: /home/alex/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jre7/1.2.21/3beb08c67673033183c8652572680587876e64b5/kotlin-stdlib-jre7-1.2.21.jar: kotlin-stdlib-jre7 is deprecated. Please use kotlin-stdlib-jdk7 instead
w: /home/alex/dev/Rocket.Chat.Kotlin.SDK.alexfdz/common/src/main/kotlin/chat/rocket/common/internal/FallbackSealedClassJsonAdapter.kt: (55, 39): Unchecked cast: Class<*>! to Class<out T>
w: /home/alex/dev/Rocket.Chat.Kotlin.SDK.alexfdz/common/src/main/kotlin/chat/rocket/common/internal/FallbackSealedClassJsonAdapter.kt: (64, 67): Unchecked cast: Class<*>! to Class<out T>
w: /home/alex/dev/Rocket.Chat.Kotlin.SDK.alexfdz/common/src/main/kotlin/chat/rocket/common/internal/FallbackSealedClassJsonAdapter.kt: (117, 93): Parameter 'moshi' is never used, could be renamed to _
w: /home/alex/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jre7/1.2.21/3beb08c67673033183c8652572680587876e64b5/kotlin-stdlib-jre7-1.2.21.jar: kotlin-stdlib-jre7 is deprecated. Please use kotlin-stdlib-jdk7 instead
w: /home/alex/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jre7/1.2.21/3beb08c67673033183c8652572680587876e64b5/kotlin-stdlib-jre7-1.2.21.jar: kotlin-stdlib-jre7 is deprecated. Please use kotlin-stdlib-jdk7 instead
w: /home/alex/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jre7/1.2.21/3beb08c67673033183c8652572680587876e64b5/kotlin-stdlib-jre7-1.2.21.jar: kotlin-stdlib-jre7 is deprecated. Please use kotlin-stdlib-jdk7 instead
w: /home/alex/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jre7/1.2.21/3beb08c67673033183c8652572680587876e64b5/kotlin-stdlib-jre7-1.2.21.jar: kotlin-stdlib-jre7 is deprecated. Please use kotlin-stdlib-jdk7 instead
w: /home/alex/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jre7/1.2.21/3beb08c67673033183c8652572680587876e64b5/kotlin-stdlib-jre7-1.2.21.jar: kotlin-stdlib-jre7 is deprecated. Please use kotlin-stdlib-jdk7 instead
w: /home/alex/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jre7/1.2.21/3beb08c67673033183c8652572680587876e64b5/kotlin-stdlib-jre7-1.2.21.jar: kotlin-stdlib-jre7 is deprecated. Please use kotlin-stdlib-jdk7 instead
w: /home/alex/dev/Rocket.Chat.Kotlin.SDK.alexfdz/core/src/main/kotlin/chat/rocket/core/internal/SettingsAdapter.kt: (88, 21): 'when' expression on enum is recommended to be exhaustive, add 'BEGIN_ARRAY', 'END_ARRAY', 'END_OBJECT', 'NAME', 'END_DOCUMENT' branches or 'else' branch instead
w: /home/alex/dev/Rocket.Chat.Kotlin.SDK.alexfdz/core/src/main/kotlin/chat/rocket/core/internal/realtime/socket/Socket.kt: (245, 32): Parameter 'type' is never used
w: /home/alex/dev/Rocket.Chat.Kotlin.SDK.alexfdz/core/src/main/kotlin/chat/rocket/core/model/url/Meta.kt: (66, 59): Parameter 'annotations' is never used, could be renamed to _
w: /home/alex/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jre7/1.2.21/3beb08c67673033183c8652572680587876e64b5/kotlin-stdlib-jre7-1.2.21.jar: kotlin-stdlib-jre7 is deprecated. Please use kotlin-stdlib-jdk7 instead

> Task :core:lintKotlinMain FAILED
Lint error > src/main/kotlin/chat/rocket/core/internal/rest/Channel.kt:11:1: Unused import

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':core:lintKotlinMain'.
> Kotlin source failed lint check.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.

* Get more help at https://help.gradle.org

BUILD FAILED in 11s
24 actionable tasks: 21 executed, 3 up-to-date
```

The same failure has been raised by CI: https://circleci.com/gh/RocketChat/Rocket.Chat.Kotlin.SDK/299