### PR TITLE
[UPDATE] Update the user querying api method to include offset and count fields

### DIFF
--- a/core/src/main/kotlin/chat/rocket/core/internal/rest/ChatRoom.kt
+++ b/core/src/main/kotlin/chat/rocket/core/internal/rest/ChatRoom.kt
@@ -152,9 +152,11 @@ suspend fun RocketChatClient.joinChat(roomId: String): Boolean = withContext(Com
  * @param queryParam Parameter which is used to query users on the basis of regex.
  * @return The list of user of a chat room that satisfies a query.
  */
-suspend fun RocketChatClient.queryUsers(queryParam: String): PagedResult<List<User>> = withContext(CommonPool) {
+suspend fun RocketChatClient.queryUsers(queryParam: String, count: Long, offset: Long): PagedResult<List<User>> = withContext(CommonPool) {
     val httpUrl = requestUrl(restUrl, "users.list")
         .addQueryParameter("query", "{ \"name\": { \"\\u0024regex\": \"$queryParam\" } }")
+        .addQueryParameter("offset", offset.toString())
+        .addQueryParameter("count", count.toString())
         .build()
     val request = requestBuilder(httpUrl).get().build()
     val type = Types.newParameterizedType(

--- a/core/src/test/kotlin/chat/rocket/core/internal/rest/ChatRoomTest.kt
+++ b/core/src/test/kotlin/chat/rocket/core/internal/rest/ChatRoomTest.kt
@@ -117,12 +117,12 @@ class ChatRoomTest {
     fun `queryUsers() should succeed without throwing`() {
         mockServer.expect()
                 .get()
-                .withPath("/api/v1/users.list?query=%7B%20%22name%22%3A%20%7B%20%22%5Cu0024regex%22%3A%20%22g%22%20%7D%20%7D")
+                .withPath("/api/v1/users.list?query=%7B%20%22name%22%3A%20%7B%20%22%5Cu0024regex%22%3A%20%22g%22%20%7D%20%7D&offset=0&count=1")
                 .andReturn(200, QUERY_USERS_SUCCESS)
                 .once()
 
         runBlocking {
-            sut.queryUsers("g")
+            sut.queryUsers("g",1,0)
         }
     }
 
@@ -130,12 +130,12 @@ class ChatRoomTest {
     fun `queryUsers() should fail with RocketChatAuthException if not logged in`() {
         mockServer.expect()
                 .get()
-                .withPath("/api/v1/users.list?query=%7B%20%22name%22%3A%20%7B%20%22%5Cu0024regex%22%3A%20%22g%22%20%7D%20%7D")
+                .withPath("/api/v1/users.list?query=%7B%20%22name%22%3A%20%7B%20%22%5Cu0024regex%22%3A%20%22g%22%20%7D%20%7D&offset=0&count=1")
                 .andReturn(401, MUST_BE_LOGGED_ERROR)
                 .once()
 
         runBlocking {
-            sut.queryUsers("g")
+            sut.queryUsers("g",1,0)
         }
     }
 
@@ -145,12 +145,12 @@ class ChatRoomTest {
     fun `queryUsers() should fail because of incorrect param`() {
         mockServer.expect()
                 .get()
-                .withPath("/api/v1/users.list?query=%7B%20%22name%22%3A%20%7B%20%22%5Cu0024regex%22%3A%20%22g%22%20%7D%20%7D")
+                .withPath("/api/v1/users.list?query=%7B%20%22name%22%3A%20%7B%20%22%5Cu0024regex%22%3A%20%22g%22%20%7D%20%7D&offset=0&count=1")
                 .andReturn(400, INCORRECT_PARAM_PROVIDED)
                 .once()
 
         runBlocking {
-            sut.queryUsers("g")
+            sut.queryUsers("g",1,0)
         }
     }
 }


### PR DESCRIPTION
This pull request updates [this](https://rocket.chat/docs/developer-guides/rest-api/users/list/) api call method to include `count` and `offset` as query params as stated [here](https://rocket.chat/docs/developer-guides/rest-api/offset-and-count-and-sort-info/)

This pr is necessary for [this](https://github.com/RocketChat/Rocket.Chat.Android/pull/891) feature in the android app.