### PR TITLE
[FIX] Set sourceCompatibility to java 1.8 through all modules

### DIFF
--- a/compat/build.gradle
+++ b/compat/build.gradle
@@ -8,6 +8,8 @@ apply plugin: 'kotlin'
 apply plugin: 'org.jetbrains.dokka'
 apply plugin: "org.jmailen.kotlinter"
 
+sourceCompatibility = JavaVersion.VERSION_1_8
+
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${versions.kotlin}"
     compile "org.jetbrains.kotlinx:kotlinx-coroutines-core:${versions.coroutine}"

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -9,6 +9,8 @@ apply plugin: 'kotlin-kapt'
 apply plugin: 'org.jetbrains.dokka'
 apply plugin: "org.jmailen.kotlinter"
 
+sourceCompatibility = JavaVersion.VERSION_1_8
+
 dependencies {
     compile project (':common')
 

--- a/rxjava/build.gradle
+++ b/rxjava/build.gradle
@@ -7,6 +7,8 @@ apply plugin: 'kotlin'
 apply plugin: 'java'
 apply plugin: 'org.jetbrains.dokka'
 
+sourceCompatibility = JavaVersion.VERSION_1_8
+
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${versions.kotlin}"
 


### PR DESCRIPTION
Jetifier seems to have a problem when transforming the generated sdk jar files as observed here:

https://github.com/RocketChat/Rocket.Chat.Android/issues/1636

By doing `./gradlew assemblePlayDebug --stacktrace` I got the following (partial) stack:

```
Caused by: java.lang.IllegalArgumentException
        at org.objectweb.asm.ClassReader.<init>(ClassReader.java:160)
        at org.objectweb.asm.ClassReader.<init>(ClassReader.java:143)
        at com.android.tools.build.jetifier.processor.transform.bytecode.ByteCodeTransformer.runTransform(ByteCodeTransformer.kt:35)
        at com.android.tools.build.jetifier.processor.Processor.visit(Processor.kt:328)
        at com.android.tools.build.jetifier.processor.archive.ArchiveFile.accept(ArchiveFile.kt:41)
        at com.android.tools.build.jetifier.processor.Processor.visit(Processor.kt:316)
        at com.android.tools.build.jetifier.processor.archive.Archive.accept(Archive.kt:66)
        at com.android.tools.build.jetifier.processor.Processor.transformLibrary(Processor.kt:312)
        at com.android.tools.build.jetifier.processor.Processor.transform(Processor.kt:175)
        at com.android.build.gradle.internal.dependency.JetifyTransform.transform(JetifyTransform.kt:199)

```
By digging at the source code pointed here [https://android.googlesource.com/toolchain/jill/+/67b2276b6c33a60d49c75e818120dfa9478fa0cd/asm4/src/org/objectweb/asm/ClassReader.java#169](url)

led to the thought that Jetfier might have a limitation on the compiled java version. I could see then, not all sdk modules were set to a specific source compatibility. Next step was to cap all modules to 1.7, then it worked. From there, I increased all to 1.8 and still worked.
The problem seems to maybe differente modules being compiled by different versions of the java compiler, and thus generating different magic number signatures on classes for different modules (or so I suppose). 
This PR should fix the issue.
