### PR TITLE
Added US Locale param to SimpleDateFormat for correct date formatting

### DIFF
--- a/common/src/main/kotlin/chat/rocket/common/util/CalendarISO8601Converter.kt
+++ b/common/src/main/kotlin/chat/rocket/common/util/CalendarISO8601Converter.kt
@@ -4,6 +4,7 @@ import java.text.ParseException
 import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.TimeZone
+import java.util.Locale
 
 class CalendarISO8601Converter : ISO8601Converter {
 
@@ -13,7 +14,7 @@ class CalendarISO8601Converter : ISO8601Converter {
         calendar.timeInMillis = timestamp
 
         // Quoted "Z" to indicate UTC, no timezone offset
-        val df = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+        val df = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US)
         df.timeZone = tz
 
         return df.format(calendar.time)


### PR DESCRIPTION
Currently, if Android Phone is in a language that doesn't use integers to represent numbers the date created for API requests are unreadable by the server. 

Example: 

When loading subscriptions, you hit the `api/v1/subscriptions.get?updatedSince=` endpoint where _updatedSince_ is a date.
If the phone is in Locale that uses integers as numbers, the date generated is of the format: `1970-01-01T00%3A00%3A00.000Z`
If the phone is in Locale that uses symbols as numbers, the date generated is of the format: `%D9%A2%D9%A0%D9%A1%D9%A8-%D9%A1%D9%A0-%D9%A1%D9%A7T%D9%A1%D9%A9%3A%D9%A4%D9%A7%3A%D9%A1%D9%A9.%D9%A0%D9%A8%D9%A2Z`

In the `fromTimestamp` function in `CalendarISO8601` class, I added `Locale.US` as a param to SimpleDateFormat so that no matter the Locale of the phone, the date created is readable by the server.

For more information, see [this issue](https://github.com/RocketChat/Rocket.Chat.Android/issues/1772) I originally posted on
