### PR TITLE
[FIX] Update endoint

### DIFF
--- a/core/src/main/kotlin/chat/rocket/core/internal/rest/CustomEmoji.kt
+++ b/core/src/main/kotlin/chat/rocket/core/internal/rest/CustomEmoji.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
 suspend fun RocketChatClient.getCustomEmojis(): List<CustomEmoji> = withContext(Dispatchers.IO) {
-    val url = requestUrl(restUrl, "emoji-custom").build()
+    val url = requestUrl(restUrl, "emoji-custom.list").build()
 
     val request = requestBuilderForAuthenticatedMethods(url).get().build()
 

--- a/core/src/test/kotlin/chat/rocket/core/internal/rest/CustomEmojiTest.kt
+++ b/core/src/test/kotlin/chat/rocket/core/internal/rest/CustomEmojiTest.kt
@@ -413,7 +413,7 @@ class CustomEmojiTest {
     fun `getCustomEmojis() should return list of custom emojis`() {
         mockServer.expect()
             .get()
-            .withPath("/api/v1/emoji-custom")
+            .withPath("/api/v1/emoji-custom.list")
             .andReturn(200, EMOJI_CUSTOM_OK)
             .once()
 


### PR DESCRIPTION
emoji-custom is now deprecated in favor of emoji-custom.list.